### PR TITLE
GO-4061 Fix tantivy installation

### DIFF
--- a/.github/workflows/parse-new-experience.yml
+++ b/.github/workflows/parse-new-experience.yml
@@ -115,6 +115,12 @@ jobs:
           repository: anyproto/anytype-heart
           path: anytype-heart
 
+      - name: Download validator dependencies
+        if: ${{ env.zip_file_missing == 'false' && env.restrictions_exceeded == 'false' && env.incorrect_screen_format == 'false' && github.event.label.name != 'skip_validation' }}
+        run: |
+          cd anytype-heart
+          make download-tantivy
+
       - name: Run experience validator
         id: experience-validator
         if: ${{ env.zip_file_missing == 'false' && env.restrictions_exceeded == 'false' && env.incorrect_screen_format == 'false' && github.event.label.name != 'skip_validation' }}


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4061/fix-validator-build-in-gallery

Fix validator build by adding **tantivy** lib installation step